### PR TITLE
🔧 update: improve configurability for webhooks and ticket creation

### DIFF
--- a/src/__tests__/env.test.ts
+++ b/src/__tests__/env.test.ts
@@ -7,6 +7,7 @@ import {
   getConfiguredBotUsername,
   getDefaultTicketPriority,
   getEnvVar,
+  getWebhookPollInterval,
   isDevelopment,
   isProduction
 } from '../config/env.ts';
@@ -138,6 +139,35 @@ describe('env utilities', () => {
       process.env.UNTHREAD_DEFAULT_PRIORITY = '5';
       
       expect(getDefaultTicketPriority()).toBe(5);
+    });
+  });
+
+  describe('getWebhookPollInterval', () => {
+    it('should return undefined when not set', () => {
+      delete process.env.WEBHOOK_POLL_INTERVAL;
+
+      expect(getWebhookPollInterval()).toBeUndefined();
+    });
+
+    it('should return configured poll interval when set to a positive integer', () => {
+      process.env.WEBHOOK_POLL_INTERVAL = '5000';
+
+      expect(getWebhookPollInterval()).toBe(5000);
+    });
+
+    it('should trim whitespace around configured poll interval', () => {
+      process.env.WEBHOOK_POLL_INTERVAL = '  2500  ';
+
+      expect(getWebhookPollInterval()).toBe(2500);
+    });
+
+    it('should return undefined for invalid poll intervals', () => {
+      const invalidIntervals = ['0', '-1', 'abc', '1000ms', '1.5', ''];
+
+      for (const invalidInterval of invalidIntervals) {
+        process.env.WEBHOOK_POLL_INTERVAL = invalidInterval;
+        expect(getWebhookPollInterval()).toBeUndefined();
+      }
     });
   });
 

--- a/src/commands/processors/CallbackProcessors.ts
+++ b/src/commands/processors/CallbackProcessors.ts
@@ -621,6 +621,13 @@ export class SupportCallbackProcessor implements ICallbackProcessor {
                 email: userState.email // Must exist at this point
             };
 
+            // Resolve customer dynamically from current chat context.
+            const chatId = ctx.chat?.id ?? userId;
+            const chatTitle = ctx.chat && 'title' in ctx.chat && ctx.chat.title
+                ? ctx.chat.title
+                : 'Telegram Support';
+            const customer = await unthreadService.getOrCreateCustomer(chatTitle, chatId);
+
             // Use unified approach: create ticket with attachments in single API call when attachments exist
             let ticketResponse;
             
@@ -662,18 +669,16 @@ export class SupportCallbackProcessor implements ICallbackProcessor {
                         
                         // Fallback to standard ticket creation without attachments
                         ticketResponse = await unthreadService.createTicket({
-                            groupChatName: 'Telegram Support', // Default group chat name
-                            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                            customerId: process.env.UNTHREAD_CUSTOMER_ID!,
+                            groupChatName: chatTitle,
+                            customerId: customer.id,
                             summary: userState.summary,
                             onBehalfOf
                         });
                     } else {
                         // Use unified ticket creation with buffer attachments
                         ticketResponse = await unthreadService.createTicketWithBufferAttachments({
-                            groupChatName: 'Telegram Support', // Default group chat name
-                            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                            customerId: process.env.UNTHREAD_CUSTOMER_ID!,
+                            groupChatName: chatTitle,
+                            customerId: customer.id,
                             summary: userState.summary,
                             onBehalfOf,
                             attachments: attachmentBuffers
@@ -695,9 +700,8 @@ export class SupportCallbackProcessor implements ICallbackProcessor {
                     
                     // Fallback to standard ticket creation
                     ticketResponse = await unthreadService.createTicket({
-                        groupChatName: 'Telegram Support', // Default group chat name
-                        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                        customerId: process.env.UNTHREAD_CUSTOMER_ID!,
+                        groupChatName: chatTitle,
+                        customerId: customer.id,
                         summary: userState.summary,
                         onBehalfOf
                     });
@@ -705,9 +709,8 @@ export class SupportCallbackProcessor implements ICallbackProcessor {
             } else {
                 // Standard ticket creation without attachments
                 ticketResponse = await unthreadService.createTicket({
-                    groupChatName: 'Telegram Support', // Default group chat name
-                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                    customerId: process.env.UNTHREAD_CUSTOMER_ID!,
+                    groupChatName: chatTitle,
+                    customerId: customer.id,
                     summary: userState.summary,
                     onBehalfOf
                 });
@@ -736,9 +739,8 @@ export class SupportCallbackProcessor implements ICallbackProcessor {
                 messageId: ctx.callbackQuery?.message?.message_id || 0, // Use callback message ID
                 ticketId: ticket.id,
                 friendlyId: ticket.friendlyId,
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                customerId: process.env.UNTHREAD_CUSTOMER_ID!,
-                chatId: ctx.chat?.id || 0,
+                customerId: customer.id,
+                chatId,
                 telegramUserId: userId,
                 summary: userState.summary
             });

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -284,6 +284,36 @@ export function getDefaultTicketPriority(): 3 | 5 | 7 | 9 | undefined {
 }
 
 /**
+ * Returns the webhook polling interval when explicitly configured.
+ *
+ * If WEBHOOK_POLL_INTERVAL is unset or invalid, returns undefined so the
+ * webhook consumer can use its built-in default interval.
+ *
+ * @returns The configured polling interval in milliseconds, or undefined
+ */
+export function getWebhookPollInterval(): number | undefined {
+    const rawPollInterval = process.env.WEBHOOK_POLL_INTERVAL?.trim();
+
+    if (!rawPollInterval) {
+        return undefined;
+    }
+
+    if (!/^\d+$/.test(rawPollInterval)) {
+        LogEngine.warn(`⚠️  Invalid WEBHOOK_POLL_INTERVAL value: ${rawPollInterval}. Must be a positive integer in milliseconds. Using default interval.`);
+        return undefined;
+    }
+
+    const pollInterval = Number(rawPollInterval);
+
+    if (!Number.isSafeInteger(pollInterval) || pollInterval <= 0) {
+        LogEngine.warn(`⚠️  Invalid WEBHOOK_POLL_INTERVAL value: ${rawPollInterval}. Must be a positive integer in milliseconds. Using default interval.`);
+        return undefined;
+    }
+
+    return pollInterval;
+}
+
+/**
  * Returns an array of authorized Telegram user IDs parsed from the ADMIN_USERS environment variable.
  *
  * Throws an error if ADMIN_USERS is missing, contains only placeholder values, or no valid numeric IDs are found. Invalid IDs are skipped with a warning.

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ import './config/logging.js';
 import { LogEngine } from '@wgtechlabs/log-engine';
 
 // Validate environment configuration before proceeding
-import { validateEnvironment } from './config/env.js';
+import { getWebhookPollInterval, validateEnvironment } from './config/env.js';
 validateEnvironment();
 
 import { cleanupBlockedUser, createBot, startPolling } from './bot.js';
@@ -337,10 +337,13 @@ let webhookHandler: TelegramWebhookHandler | undefined;
 try {
     // Check if webhook Redis URL is available before initializing webhook consumer
     if (process.env.WEBHOOK_REDIS_URL) {
+        const webhookPollInterval = getWebhookPollInterval();
+
         // Initialize webhook consumer with dedicated webhook Redis URL
         webhookConsumer = new WebhookConsumer({
             redisUrl: process.env.WEBHOOK_REDIS_URL,
-            queueName: 'unthread-events'
+            queueName: 'unthread-events',
+            ...(webhookPollInterval !== undefined ? { pollInterval: webhookPollInterval } : {})
         });
 
         // Initialize webhook handler


### PR DESCRIPTION
## Summary
This PR improves runtime configurability across two areas: webhook polling and support ticket creation. The webhook consumer now respects a configurable poll interval via environment variable instead of relying on a hardcoded default. Ticket creation now dynamically resolves the customer from the active chat context rather than using a static `UNTHREAD_CUSTOMER_ID` environment variable, enabling correct customer attribution in multi-chat scenarios.

## Changes
- 📦 Added `getWebhookPollInterval` config utility that reads and validates `WEBHOOK_POLL_INTERVAL` from the environment, returning `undefined` for missing or invalid values (non-positive, non-integer, or non-numeric)
- 🔧 Applied the configurable poll interval to `WebhookConsumer`, replacing any hardcoded interval logic
- 🔧 Resolved customer dynamically in `SupportCallbackProcessor` by deriving `chatId` and `chatTitle` from `ctx.chat` context and calling `getOrCreateCustomer`, replacing the hardcoded `'Telegram Support'` label and static `process.env.UNTHREAD_CUSTOMER_ID`

## Test Plan
- Added unit tests for `getWebhookPollInterval` covering: unset env var returns `undefined`, valid positive integer is parsed correctly, whitespace is trimmed, and invalid values (`0`, negative, non-numeric, float, empty string) all return `undefined`
- Existing tests for `SupportCallbackProcessor` and `WebhookConsumer` should continue to pass; verify ticket creation in a live or staging Telegram chat to confirm correct customer resolution