### PR TITLE
🔧 update: improve ticket notification message clarity and reply UX

### DIFF
--- a/src/__tests__/globalTemplates.test.ts
+++ b/src/__tests__/globalTemplates.test.ts
@@ -93,7 +93,7 @@ describe('globalTemplates', () => {
       });
 
       it('should have appropriate messaging for agent responses', () => {
-        expect(template.content).toContain('New Response');
+        expect(template.content).toContain('Update on Ticket');
         expect(template.content).toContain('continue the conversation');
       });
     });

--- a/src/config/globalTemplates.ts
+++ b/src/config/globalTemplates.ts
@@ -41,8 +41,8 @@ export const DEFAULT_GLOBAL_TEMPLATES: GlobalTemplateConfig = {
     },
     agent_response: {
       event: 'agent_response',
-      content: '💬 **New Response for Ticket #{{ticketNumber}}**\n\n' +
-               'Message: {{response}}\n\n' +
+      content: '💬 **Update on Ticket #{{ticketNumber}}**\n\n' +
+               '{{response}}\n\n' +
                '*Reply to this message to continue the conversation.*',
       enabled: true
     },

--- a/src/handlers/webhookMessage.ts
+++ b/src/handlers/webhookMessage.ts
@@ -442,7 +442,7 @@ export class TelegramWebhookHandler {
     if (cleanText.length > maxLength) {
       truncatedText = cleanText.substring(0, maxLength - 50) + '...\n\n_Message truncated_';
     }
-    return `🎫 Ticket #${friendlyId}\n\n💬 Response:\n${truncatedText}\n\n──────────\n📝 Reply to this message to respond or add more info to your ticket.`;
+    return `💬 Update on Ticket #${friendlyId}\n\n${truncatedText}\n\nReply to this message to continue the conversation.`;
   }
 
   /**

--- a/src/handlers/webhookMessage.ts
+++ b/src/handlers/webhookMessage.ts
@@ -1435,6 +1435,17 @@ export class TelegramWebhookHandler {
         for (const sentMsgId of fallbackSentIds) {
           await this.storeAttachmentAgentMessage(sentMsgId, conversationId, chatId, ticketData);
         }
+
+        const latestFallbackMessageId = fallbackSentIds.at(-1);
+        if (latestFallbackMessageId !== undefined) {
+          await this.sendAttachmentReplyGuidance(
+            conversationId,
+            chatId,
+            latestFallbackMessageId,
+            ticketData,
+            fallbackSentIds.length
+          );
+        }
       }
       return;
     }
@@ -1443,6 +1454,7 @@ export class TelegramWebhookHandler {
     const supportedImageTypes = this.imageConfig.supportedFormats;
 
     let processedCount = 0;
+    let lastSentMessageId: number | null = null;
     for (let i = 0; i < files.length; i++) {
       const file = files.at(i);
       
@@ -1514,6 +1526,7 @@ export class TelegramWebhookHandler {
 
         if (sentMsgId !== null && ticketData) {
           await this.storeAttachmentAgentMessage(sentMsgId, conversationId, chatId, ticketData);
+          lastSentMessageId = sentMsgId;
         }
 
         processedCount++;
@@ -1536,6 +1549,79 @@ export class TelegramWebhookHandler {
       skippedFiles: files.length - processedCount,
       processingTimeMs: Date.now() - startTime,
       efficiency: 'metadata-first'
+    });
+
+    if (ticketData && lastSentMessageId !== null) {
+      await this.sendAttachmentReplyGuidance(
+        conversationId,
+        chatId,
+        lastSentMessageId,
+        ticketData,
+        processedCount
+      );
+    }
+  }
+
+  /**
+   * Send a short note after dashboard attachments so the newest reply target is obvious.
+   */
+  private async sendAttachmentReplyGuidance(
+    conversationId: string,
+    chatId: number,
+    replyToMessageId: number,
+    ticketData: any,
+    attachmentCount: number
+  ): Promise<void> {
+    const guidanceMessage =
+      `📝 Attachment delivery complete for Ticket #${escapeMarkdown(String(ticketData.friendlyId))}.\n\n` +
+      `Reply to this message to continue the conversation for Ticket #${escapeMarkdown(String(ticketData.friendlyId))}.`;
+
+    const guidanceNote = await this.safeSendMessage(
+      chatId,
+      guidanceMessage,
+      {
+        reply_to_message_id: replyToMessageId,
+        parse_mode: 'Markdown',
+        disable_web_page_preview: true
+      }
+    );
+
+    if (!guidanceNote) {
+      LogEngine.warn('Attachment reply guidance note was not delivered', {
+        conversationId,
+        chatId,
+        replyToMessageId,
+        attachmentCount
+      });
+      return;
+    }
+
+    await this.botsStore.storeAgentMessage({
+      messageId: guidanceNote.message_id,
+      conversationId,
+      chatId,
+      friendlyId: ticketData.friendlyId,
+      originalTicketMessageId: ticketData.messageId,
+      sentAt: new Date().toISOString()
+    });
+
+    await this.botsStore.storage.set(
+      `agent_message:${conversationId}:latest`,
+      JSON.stringify({
+        messageId: guidanceNote.message_id,
+        conversationId,
+        chatId,
+        sentAt: new Date().toISOString()
+      }),
+      60 * 60 * 24
+    );
+
+    LogEngine.info('Attachment reply guidance note delivered', {
+      conversationId,
+      chatId,
+      attachmentCount,
+      guidanceMessageId: guidanceNote.message_id,
+      replyToMessageId
     });
   }
 


### PR DESCRIPTION
## Summary
Cleans up the wording and structure of agent response notifications in both global templates and the webhook message handler, while also adding a follow-up guidance message after attachment delivery so users always have a clear reply target.

## Changes
- Renamed `💬 **New Response for Ticket #…**` heading to `💬 **Update on Ticket #…**` in the `agent_response` global template for more natural phrasing
- Removed the redundant `Message:` prefix so the response body is rendered directly without extra label noise
- Applied the same simplified format to the webhook message formatter (`formatAgentResponseForTelegram`)
- Added `sendAttachmentReplyGuidance` private method that sends a short confirmation note (replying to the last delivered attachment message) once all attachments have been forwarded, covering both the fallback path and the normal processed-file path
- Updated unit test assertion to match the new `Update on Ticket` wording

## Test Plan
- Existing `globalTemplates` test suite updated and passing — verifies the new heading text and `continue the conversation` copy are present
- Manually verify in a Telegram test environment that: (1) agent response messages render without the `Message:` label, (2) after multi-attachment delivery a guidance reply message appears threaded to the last attachment, and (3) the fallback path also triggers the guidance note